### PR TITLE
added multiple requests support for equipment slots

### DIFF
--- a/api/definition/definition.js
+++ b/api/definition/definition.js
@@ -1,101 +1,10 @@
-const axios = require('axios')
-const jsonata = require('jsonata')
-const { param, query, validationResult } = require('express-validator')
-const createError = require('http-errors')
-const logger = require('../../winston')
 const express = require('express')
+
+const inventoryItemController = require('./inventory-item')
+const equipmentSlotController = require('./equipment-slot')
 
 const router = express.Router()
 
-/* GET Definition */
-router.get('/definition/:category', [
-  // validations
-  param('category').isIn(['inventoryItem', 'equipmentSlot']).withMessage('must be \'inventoryItem\' or \'equipmentSlot\''),
-  query('hash').notEmpty().withMessage('required parameter').isInt().withMessage('must be an integer')
-], (req, res, next) => {
-  // validation error response
-  const errors = validationResult(req)
-  if (!errors.isEmpty()) {
-    const message = { errors: errors.array() }
-
-    logger.warn({ message: req.path, bad: message })
-
-    return res.status(422).json(message)
-  }
-
-  logger.debug({ message: req.path, headers: req.headers, request: req.query })
-
-  return definitionService(req, res).then(response => {
-    logger.debug({ message: req.path, clientResponse: response })
-
-    if (Object.keys(response).length === 0 && response.constructor === Object) {
-      throw createError(500, 'the hash provided does not apply to the given category parameter.')
-    }
-
-    return res.status(200).json(response)
-  }).catch(error => {
-    next(error)
-    return
-  })
-})
+router.use('/definition', inventoryItemController, equipmentSlotController)
 
 module.exports = router
-
-async function definitionService (req, next) {
-  // request options
-  const definitionOption = {
-    method: 'GET',
-    headers: {
-      'X-API-Key': process.env.API_KEY
-    }
-  }
-
-  switch (req.params.category) {
-    case 'inventoryItem':
-      definitionOption.url = `${process.env.BUNGIE_DOMAIN}/Platform/Destiny2/Manifest/DestinyInventoryItemDefinition/${req.query.hash}`
-      break
-    case 'equipmentSlot':
-      definitionOption.url = `${process.env.BUNGIE_DOMAIN}/Platform/Destiny2/Manifest/DestinyEquipmentSlotDefinition/${req.query.hash}`
-      break
-    default:
-      // shouldn't be reachable but if so, throw an error.
-      throw createError(422, 'not a valid value for the route \'api/definition/:category\'')
-  }
-
-  // request characters
-  let definitionResponse
-  try {
-    definitionResponse = await request(definitionOption, req)
-  } catch (error) {
-    throw (error.response)
-  }
-
-  // trim content
-  const response = transform(definitionResponse)
-
-  return response
-}
-
-async function request (definitionOption, req) {
-  logger.debug({ message: req.path, options: definitionOption })
-
-  const definitionResponse = await axios(definitionOption)
-
-  logger.debug({ message: req.path, bungieResponse: definitionResponse.data })
-
-  return definitionResponse.data
-}
-
-function transform (definitionResponse) {
-  // expression for transforming the response
-  const expression =
-        jsonata(`{
-            "name": Response.displayProperties.name,
-            "maxStackSize": Response.inventory.maxStackSize
-        }`)
-
-  // response transformed
-  const response = expression.evaluate(definitionResponse)
-
-  return response
-}

--- a/api/definition/equipment-slot.js
+++ b/api/definition/equipment-slot.js
@@ -1,0 +1,165 @@
+const axios = require('axios')
+const jsonata = require('jsonata')
+const { query, body, validationResult } = require('express-validator')
+const createError = require('http-errors')
+const logger = require('../../winston')
+const express = require('express')
+
+const router = express.Router()
+
+/* GET Definition */
+router.get('/equipment-slot', [
+  // validations
+  query('inventoryHash').optional().isInt().withMessage('must be an int'),
+  query('equipmentSlotHash').optional().isInt().withMessage('must be an integer').custom((value, { req }) => {
+    if (value && req.query.inventoryHash) {
+      throw new Error('must be omitted if an inventoryHash is provided')
+    } else {
+      return true
+    }
+  })
+], (req, res, next) => {
+  // validation error response
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    const message = { errors: errors.array() }
+
+    logger.warn({ message: req.path, bad: message })
+
+    return res.status(422).json(message)
+  }
+
+  logger.debug({ message: req.path, headers: req.headers, request: req.query })
+
+  if (req.query.inventoryHash) {
+    return inventoryItemService(req, req.query.inventoryHash).then(inventoryItemResponse => {
+      logger.debug({ message: `${req.path} - inventoryItem`, clientResponse: inventoryItemResponse })
+
+      return equipmentSlotService(req, inventoryItemResponse.equipmentSlotHash, req.query.inventoryHash, inventoryItemResponse.name).then(equipmentSlotResponse => {
+        logger.debug({ message: `${req.path} - equipmentSlot`, clientResponse: equipmentSlotResponse })
+
+        return res.status(200).json(equipmentSlotResponse)
+      }).catch(error => {
+        next(error)
+        return
+      })
+    })
+  } else {
+    return equipmentSlotService(req, req.query.equipmentSlotHash).then(equipmentSlotResponse => {
+      logger.debug({ message: req.path, clientResponse: equipmentSlotResponse })
+
+      equipmentSlotResponse.equipmentSlotHash = req.query.equipmentSlotHash
+
+      return res.status(200).json(equipmentSlotResponse)
+    }).catch(error => {
+      next(error)
+      return
+    })
+  }
+})
+
+/* POST Definition */
+router.post('/equipment-slots', [
+  // validations
+  body('equipment').notEmpty().withMessage('required parameter').isArray().withMessage('must be an array'),
+  body('equipment[*].itemReferenceHash').notEmpty().withMessage('required parameter')
+    .isString().withMessage('must be a string')
+    .isInt().withMessage('string must only contain an integer')
+], (req, res, next) => {
+  // validation error response
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    const message = { errors: errors.array() }
+
+    logger.warn({ message: req.path, bad: message })
+
+    return res.status(422).json(message)
+  }
+
+  logger.debug({ message: req.path, headers: req.headers, request: req.query })
+
+  const requests = []
+
+  for (const item of req.body.equipment) {
+    requests.push(inventoryItemService(req, item.itemReferenceHash)
+      .then(inventoryItemResponse => {
+        logger.debug({ message: `${req.path} - inventoryItem`, clientResponse: inventoryItemResponse })
+
+        return equipmentSlotService(req, inventoryItemResponse.equipmentSlotHash, item.itemReferenceHash, inventoryItemResponse.name)
+          .then(equipmentSlotResponse => {
+            logger.debug({ message: `${req.path} - equipmentSlot`, clientResponse: equipmentSlotResponse })
+
+            return equipmentSlotResponse
+          }).catch(error => {
+            next(error)
+            return
+          })
+      }))
+  }
+
+  return Promise.all(requests).then(response => {
+    return res.status(200).json(response)
+  })
+})
+
+module.exports = router
+
+async function equipmentSlotService (req, equipmentSlotHash, itemReferenceHash, itemName) {
+  const equipmentSlotDefinitionOption = {
+    method: 'GET',
+    url: `${process.env.BUNGIE_DOMAIN}/Platform/Destiny2/Manifest/DestinyEquipmentSlotDefinition/${equipmentSlotHash}`,
+    headers: {
+      'X-API-Key': process.env.API_KEY
+    }
+  }
+
+  const bungieResponse = await request(equipmentSlotDefinitionOption, req)
+
+  // trim content
+  const clientResponse = transform(bungieResponse)
+
+  // if array is empty, then the hash isn't valid for this definition type.
+  if (Object.keys(clientResponse).length === 0 && clientResponse.constructor === Object) {
+    throw createError(500, 'the hash provided does not apply to the given category parameter.')
+  }
+
+  clientResponse.itemId = itemReferenceHash || undefined
+  clientResponse.name = itemName || undefined
+
+  return clientResponse
+}
+
+async function inventoryItemService (req, itemReferenceHash) {
+  // request options
+  const inventoryItemOption = {
+    method: 'GET',
+    url: `${req.protocol}://${process.env.SERVER_DOMAIN}/api/definition/inventory-item?inventoryHash=${itemReferenceHash}`
+  }
+
+  const inventoryItemResponse = await request(inventoryItemOption, req)
+
+  return inventoryItemResponse
+}
+
+async function request (definitionOption, req) {
+  logger.debug({ message: req.path, options: definitionOption })
+
+  const definitionResponse = await axios(definitionOption)
+
+  logger.debug({ message: req.path, definitionResponse: definitionResponse.data })
+
+  return definitionResponse.data
+}
+
+function transform (definitionResponse) {
+  // expression for transforming the response
+  const expression =
+          jsonata(`{
+              "slotType": Response.displayProperties.name
+          }`)
+
+  // response transformed
+  const response = expression.evaluate(definitionResponse)
+
+  return response
+}

--- a/api/definition/inventory-item.js
+++ b/api/definition/inventory-item.js
@@ -1,0 +1,90 @@
+const axios = require('axios')
+const jsonata = require('jsonata')
+const { query, validationResult } = require('express-validator')
+const createError = require('http-errors')
+const logger = require('../../winston')
+const express = require('express')
+
+const router = express.Router()
+
+/* GET Definition */
+router.get('/inventory-item', [
+  // validations
+  query('inventoryHash').notEmpty().withMessage('required parameter').isInt().withMessage('must be an integer')
+], (req, res, next) => {
+  // validation error response
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    const message = { errors: errors.array() }
+
+    logger.warn({ message: req.path, bad: message })
+
+    return res.status(422).json(message)
+  }
+
+  logger.debug({ message: req.path, headers: req.headers, request: req.query })
+
+  return inventoryItemService(req).then(response => {
+    logger.debug({ message: req.path, clientResponse: response })
+
+    return res.status(200).json(response)
+  }).catch(error => {
+    next(error)
+    return
+  })
+})
+
+module.exports = router
+
+async function inventoryItemService (req) {
+  // request options
+  const definitionOption = {
+    method: 'GET',
+    url: `${process.env.BUNGIE_DOMAIN}/Platform/Destiny2/Manifest/DestinyInventoryItemDefinition/${req.query.inventoryHash}`,
+    headers: {
+      'X-API-Key': process.env.API_KEY
+    }
+  }
+
+  let bungieResponse
+  try {
+    bungieResponse = await request(definitionOption, req)
+  } catch (error) {
+    throw (error.response)
+  }
+
+  // trim content
+  const clientResponse = transform(bungieResponse)
+
+  // if array is empty, then the hash isn't valid for this definition type.
+  if (Object.keys(clientResponse).length === 0 && clientResponse.constructor === Object) {
+    throw createError(500, 'the hash provided does not apply to the given category parameter.')
+  }
+
+  return clientResponse
+}
+
+async function request (definitionOption, req) {
+  logger.debug({ message: req.path, options: definitionOption })
+
+  const definitionResponse = await axios(definitionOption)
+
+  logger.debug({ message: req.path, bungieResponse: definitionResponse.data })
+
+  return definitionResponse.data
+}
+
+function transform (definitionResponse) {
+  // expression for transforming the response
+  const expression =
+          jsonata(`{
+            "name": Response.displayProperties.name,
+            "maxStackSize": Response.inventory.maxStackSize,
+            "equipmentSlotHash": Response.equippingBlock.equipmentSlotTypeHash
+        }`)
+
+  // response transformed
+  const response = expression.evaluate(definitionResponse)
+
+  return response
+}


### PR DESCRIPTION
removed the category parameter for the definition api.
separated equipment-slots and inventory-item routes into separate files.
added a post method for returning equipment slot definitions for multiple item reference hash.
